### PR TITLE
Use orange color for mentions (warnings) in Discord Dark theme

### DIFF
--- a/Discord/Discord-Dark/Discord-Dark-Theme.json
+++ b/Discord/Discord-Dark/Discord-Dark-Theme.json
@@ -4,7 +4,7 @@
     "colors": {
         "accent-color": "#747ff4",
         "primary-color": "#00aff4",
-        "warning-color": "#ed4245d9",
+        "warning-color": "#faa81ad9",
 
         "sidebar-color": "#202225",
         "roomlist-background-color": "#2f3136",


### PR DESCRIPTION
After actually using Discord theme for some time, I think the default warning color (`#ed4245`) is a bit too "dangerous-looking".
So I propose to switch it to orange instead (`#faa81a`) with the same 85% transparency.

This color is taken from the border of the highlighted message in Discord:
![mention-discord](https://user-images.githubusercontent.com/82098328/135491395-90caa21a-8078-4f51-a89b-510be2a9594f.png)

Before and after:
![mention-test_](https://user-images.githubusercontent.com/82098328/135491513-5eaaed96-f1af-407f-a3da-3371fce3cbf1.png)

This change will also make all red buttons orange, for example:
![2021-09-30_190903](https://user-images.githubusercontent.com/82098328/135491850-2ed3186d-56cc-4c11-8781-840b3f9574b0.png)

But I think it's fine. Traditionally orange is the color of warnings. And red is the color of errors.