### PR TITLE
[Discord Dark] Fix a broken color after v1.9.1/v1.9.2 update

### DIFF
--- a/Discord/Discord-Dark/Discord-Dark-Theme.json
+++ b/Discord/Discord-Dark/Discord-Dark-Theme.json
@@ -15,6 +15,8 @@
 
         "timeline-background-color": "#36393f",
         "timeline-text-color": "#dcddde",
+        "secondary-content": "#dcddde",
+        "tertiary-content": "#dcddde",
         "timeline-text-secondary-color": "#b9bbbe",
         "timeline-highlights-color": "#04040512",
         "reaction-row-button-selected-bg-color": "#b9bbbe"


### PR DESCRIPTION
Fixes issues that appeared after v1.9.1 or v1.9.2 update of Element (see https://github.com/vector-im/element-web/issues/19381)
- Invisible "Explore Space" icon
- Invisible Reaction panel icons (React/Reply/Expand quote/Options)
- No border at selected space icon

![image](https://user-images.githubusercontent.com/82098328/137737989-75d53e2f-9148-4ecd-934e-d8b063729110.png)
![2021-10-18_160109](https://user-images.githubusercontent.com/82098328/137738019-4b10d9d2-8bf0-413c-8df1-c5b851120de7.png)
![2021-10-18_160359](https://user-images.githubusercontent.com/82098328/137738476-c0376052-6a87-448b-bf37-8c5bbef0d0ef.png)

Note: we might see more variables and name changes soon. But this was the only change needed for the latest version (v1.9.2).
If you set it to `timeline-text-color` value, your theme should be fixed.