### PR TITLE
Fix two colors in Discord Dark theme for v1.9.5

### DIFF
--- a/Discord/Discord-Dark/Discord-Dark-Theme.json
+++ b/Discord/Discord-Dark/Discord-Dark-Theme.json
@@ -3,8 +3,10 @@
     "is_dark": true,
     "colors": {
         "accent-color": "#747ff4",
+        "accent": "#747ff4",
         "primary-color": "#00aff4",
         "warning-color": "#faa81ad9",
+        "alert": "#faa81ad9",
 
         "sidebar-color": "#202225",
         "roomlist-background-color": "#2f3136",


### PR DESCRIPTION
`accent-color` is renamed to `accent`, `warning-color` is renamed to `alert` in https://github.com/matrix-org/matrix-react-sdk/pull/7108 (merged into [v1.9.5](https://github.com/vector-im/element-web/releases/tag/v1.9.5) release 10 days ago).

I think it's okay to leave old variables as is for backwards compatibility and just add new ones.
Apologies for not doing it for all other themes, I just don't have time to install and test them all 😅