### PR TITLE
fix: Catppuccin Mocha roomlist-text-secondary-color contrast

### DIFF
--- a/Catppuccin/Mocha/Catppuccin-Mocha-Theme.json
+++ b/Catppuccin/Mocha/Catppuccin-Mocha-Theme.json
@@ -9,7 +9,7 @@
     "sidebar-color": "#11111b",
     "roomlist-background-color": "#181825",
     "roomlist-text-color": "#cdd6f4",
-    "roomlist-text-secondary-color": "#1e1e2e",
+    "roomlist-text-secondary-color": "#313234",
     "roomlist-highlights-color": "#45475a",
     "roomlist-separator-color": "#7f849c",
     "timeline-background-color": "#1e1e2e",


### PR DESCRIPTION
Before:
![303916514-1396cb2b-9065-4411-97ac-891a2f68887a](https://github.com/aaronraimist/element-themes/assets/9111925/1e73adb0-718f-426e-a1b5-e94006b1c9ba)

After:
![crimhk](https://github.com/aaronraimist/element-themes/assets/9111925/c49067a7-0ded-409c-b96a-a941a9f0d36c)
