### PR TITLE
Fixed a Typo

### DIFF
--- a/Discord/Discord-Black/Discord-Black-Theme.json
+++ b/Discord/Discord-Black/Discord-Black-Theme.json
@@ -9,7 +9,7 @@
         "alert": "#faa81ad9",
 
         "sidebar-color": "#000000",
-        "roomlist-background-color": "##191919",
+        "roomlist-background-color": "#191919",
         "roomlist-text-color": "#dcddde",
         "roomlist-text-secondary-color": "#8e9297",
         "roomlist-highlights-color": "#4f545c52",


### PR DESCRIPTION
A rogue `#` in a colour string prevented Discord Black from working properly.