### PR TITLE
Make notiifcation badges red for readability

### DIFF
--- a/Nord/Nord Dark/Nord Dark.json
+++ b/Nord/Nord Dark/Nord Dark.json
@@ -9,7 +9,7 @@
         "sidebar-color": "#2e3440",
         "roomlist-background-color": "#3b4252",
         "roomlist-text-color": "#ebcb8b",
-        "roomlist-text-secondary-color": "#e5e9f0",
+        "roomlist-text-secondary-color": "#bf616a",
         "roomlist-highlights-color": "#2e3440",
         "roomlist-separator-color": "#434c5e",
 


### PR DESCRIPTION
Current notification badges in Nord Dark theme are a near-white color with another white color for the text. This makes badge numbers nearly unreadable. This edit uses the red "Aurora" scheme color to make badges readable and indicate an action is required