### PR TITLE
Fix menu color for 'Discord Black'

### DIFF
--- a/Discord/Discord-Black/Discord-Black-Theme.json
+++ b/Discord/Discord-Black/Discord-Black-Theme.json
@@ -28,5 +28,36 @@
         "room-highlight-color": "#4752c4",
         "other-user-pill-bg-color": "#4752c4",
         "togglesw-off-color": "#72767d"
+    },
+    "compound": {
+        "--cpd-color-theme-bg": "#000000",
+
+        "--cpd-color-bg-canvas-default": "#000000",
+        "--cpd-color-bg-subtle-secondary": "#111111",
+        "--cpd-color-bg-subtle-primary": "#191919",
+        "--cpd-color-bg-action-primary-rest": "#dcddde",
+        "--cpd-color-bg-action-secondary-rest": "#191919",
+
+        "--cpd-color-bg-critical-primary": "#fd3f3c",
+        "--cpd-color-bg-critical-subtle": "#3a1f24",
+        "--cpd-color-bg-critical-hovered": "#fd3f3c",
+
+        "--cpd-color-bg-accent-rest": "#747ff4",
+
+        "--cpd-color-text-primary": "#dcddde",
+        "--cpd-color-text-secondary": "#b9bbbe",
+        "--cpd-color-text-action-accent": "#dcddde",
+        "--cpd-color-text-critical-primary": "#fd3f3c",
+        "--cpd-color-text-success-primary": "#4cb387",
+
+        "--cpd-color-icon-primary": "#dcddde",
+        "--cpd-color-icon-secondary": "#b9bbbe",
+        "--cpd-color-icon-tertiary": "#8e9297",
+        "--cpd-color-icon-accent-tertiary": "#747ff4",
+
+        "--cpd-color-border-interactive-primary": "#40444b",
+        "--cpd-color-border-interactive-secondary": "#2a2d31",
+        "--cpd-color-border-critical-primary": "#fd3f3c",
+        "--cpd-color-border-success-subtle": "#4cb387"
     }
 }


### PR DESCRIPTION
This updates the Discord Black theme with Compound color variables so that newer Element Web/Desktop menu surfaces are themed consistently.

The existing Discord Black theme still used only the older theme color keys, so newer Compound-based UI surfaces could fall back to incompatible colors. This adds a `compound` block based on the existing Discord Dark theme, adjusted to preserve the true-black Discord Black look.

Tested by loading the theme in Element with custom themes enabled and checking the newer menu surfaces.